### PR TITLE
Refactor claimDashboard and add shared utility controller

### DIFF
--- a/force-app/main/default/classes/ClaimsController.cls
+++ b/force-app/main/default/classes/ClaimsController.cls
@@ -2,12 +2,14 @@ public with sharing class ClaimsController {
     
     // Get associated claims based off of Account Id
     @AuraEnabled(cacheable=true)
-    public static List<Case> getClaims(List<String> fieldNames){
+    public static List<Case> getClaims(Id accountId){
         try {
-            Id userAccountId = '0014C000016ctr2QAA'; // change
-            String queryString = 'SELECT ' + String.join(fieldNames, ', ') + 
-                                ' FROM Case WHERE AccountId =:userAccountId ORDER BY CreatedDate DESC';
-            System.debug(queryString);
+
+            String queryString = 'SELECT Id, Claim_Type__c, Claim_Status__c, CreatedDate ' + 
+                                ' FROM Case' + 
+                                ' WHERE AccountId =:accountId' + 
+                                ' ORDER BY CreatedDate DESC';
+
             return Database.query(queryString);
 
         } catch (Exception e) {

--- a/force-app/main/default/classes/UserUtility.cls
+++ b/force-app/main/default/classes/UserUtility.cls
@@ -1,0 +1,16 @@
+public without sharing class UserUtility {
+    
+    // Fetches the account ID
+    @AuraEnabled(cacheable=true)
+    public static Id getPersonAccountId(){
+        try {
+            String userId = UserInfo.getUserId();
+            
+            List<Account> accounts = [SELECT Id, ownerId FROM Account WHERE isPersonAccount = true AND ownerId =:userId LIMIT 1];
+
+            return accounts[0].id;
+        } catch (Exception e) {
+            throw new AuraHandledException(e.getMessage());
+        }
+    }
+}

--- a/force-app/main/default/classes/UserUtility.cls-meta.xml
+++ b/force-app/main/default/classes/UserUtility.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/claimsDashboard/claimsDashboard.html
+++ b/force-app/main/default/lwc/claimsDashboard/claimsDashboard.html
@@ -2,7 +2,9 @@
     <div class="slds-grid slds-gutters slds-grid_align-stretch">
         <!-- Claims Table -->
         <div class="slds-col slds-size_8-of-12">
-            <c-claims-table></c-claims-table>
+            <template lwc:if={claims.length}>
+                <c-claims-table claims={claims}></c-claims-table>
+            </template>
         </div>
 
         <!-- Submit Claim Form -->

--- a/force-app/main/default/lwc/claimsDashboard/claimsDashboard.js
+++ b/force-app/main/default/lwc/claimsDashboard/claimsDashboard.js
@@ -1,7 +1,43 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, wire } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
+import CURRENT_USER_ID from '@salesforce/user/Id';
+import getPersonAccountId from '@salesforce/apex/UserUtility.getPersonAccountId';
+import getClaims from '@salesforce/apex/ClaimsController.getClaims';
 
 export default class ClaimsDashboard extends NavigationMixin(LightningElement) {
+
+    userId = CURRENT_USER_ID;
+    error;
+    claims;
+    personAccountId;
+
+    @wire(getPersonAccountId)
+    wiredAccountId({ data, error }) {
+        if (data) {
+            this.personAccountId = data;
+        } else if (error) {
+            console.error('err: ' + error);
+            this.error = error;
+        }
+    }
+
+    @wire(getClaims, {accountId: '$personAccountId'})
+    wiredClaims(result) {
+        if (result.data) {
+            this.claims = result.data.map(claim => ({
+                Id:  claim.Id,
+                IdLink: `/claims/claim-detail?recordId=${claim.Id}`,
+                Type: claim.Claim_Type__c,
+                Status: claim.Claim_Status__c,
+                Created: claim.CreatedDate,
+            }))
+            
+        } else {
+            this.error = result.error;
+            this.claims = [];
+            console.error(result.error);
+        }
+    }
 
     handleCreateClaim() {
         this[NavigationMixin.Navigate]({

--- a/force-app/main/default/lwc/claimsTable/claimsTable.js
+++ b/force-app/main/default/lwc/claimsTable/claimsTable.js
@@ -1,11 +1,7 @@
-import getClaims from '@salesforce/apex/ClaimsController.getClaims';
-import { LightningElement, wire } from 'lwc';
-import { refreshApex } from '@salesforce/apex';
+import { api, LightningElement } from 'lwc';
 
 export default class ClaimsTable extends LightningElement {
-
-    claims = []
-    error;
+    @api claims;
 
     tableRowData = [];
     tableColData = [
@@ -17,32 +13,6 @@ export default class ClaimsTable extends LightningElement {
         {label: 'Status', fieldName: 'Status', type: 'text', hideDefaultActions: 'true', resizable: 'false' },
         {label: 'Date Opened', fieldName: 'Created', type: 'date', hideDefaultActions: 'true', resizable: 'false' }
     ];
-
-
-    fieldNames = ['Id', 'Claim_Type__c', 'Claim_Status__c', 'CreatedDate'];
-
-    @wire(getClaims, {fieldNames: '$fieldNames'})
-    wiredClaims(result) {
-        if (result.data) {
-            this.claims = result.data.map(claim => ({
-                Id:  claim.Id,
-                IdLink: `/claims/claim-detail?recordId=${claim.Id}`,
-                Type: claim.Claim_Type__c,
-                Status: claim.Claim_Status__c,
-                Created: claim.CreatedDate,
-            }))
-            
-        } else {
-            this.error = result.error;
-            this.claims = [];
-            console.error(result.error);
-        }
-    }
-
-    refreshTable() {
-        refreshApex(this.wiredClaims);
-    }
-    
 }
 
 


### PR DESCRIPTION
Added a utility class to retrieve the accoundId from the current logged in user.
- From my understanding, even though its an extra call the cacheable=true will persist it across the components that need it so it wouldn't need to be refresh unless a user logs out.
- Keeps things separated for easier testing and reusability

Refactored the claimsDashboard(parent) so that it handles the api calls and the claimTable(child) component will only be passed in data.